### PR TITLE
WIP: Allow tests to run outside docker, mock redis and use in mem sqlite

### DIFF
--- a/backend/classifiers/base_model.py
+++ b/backend/classifiers/base_model.py
@@ -1,7 +1,6 @@
 import hashlib
 import importlib
 import json
-import lzma
 import os
 from pathlib import Path
 import random
@@ -15,7 +14,6 @@ from redis_lock import Lock
 import requests
 
 
-r = redis.Redis(host=os.environ.get('REDIS_HOST', '127.0.0.1'))
 graph_cache = {}
 
 
@@ -45,6 +43,7 @@ class BaseModel:
         if not lock_name:
             lock_name = 'classifier_{}_download'.format(self.name)
 
+        r = redis.Redis(host=os.environ.get('REDIS_HOST', '127.0.0.1'))
         with Lock(r, lock_name):
             try:
                 with open(version_file) as f:

--- a/backend/classifiers/color/model.py
+++ b/backend/classifiers/color/model.py
@@ -1,9 +1,8 @@
+import operator
+import sys
 from collections import defaultdict
 from colorsys import rgb_to_hsv
-import operator
 from pathlib import Path
-import re
-import sys
 
 import numpy as np
 from PIL import Image

--- a/backend/classifiers/style/model.py
+++ b/backend/classifiers/style/model.py
@@ -16,7 +16,6 @@ except ValueError:
     from base_model import BaseModel
 
 
-r = redis.Redis(host=os.environ.get('REDIS_HOST', '127.0.0.1'))
 GRAPH_FILE = os.path.join('style', 'graph.pb')
 LABEL_FILE = os.path.join('style', 'labels.txt')
 
@@ -38,6 +37,7 @@ class StyleModel(BaseModel):
             self.labels = self.load_labels(label_file)
 
     def load_graph(self, graph_file):
+        r = redis.Redis(host=os.environ.get('REDIS_HOST', '127.0.0.1'))
         with Lock(r, 'classifier_{}_load_graph'.format(self.name)):
             if self.graph_cache_key in self.graph_cache:
                 return self.graph_cache[self.graph_cache_key]

--- a/backend/photos/models.py
+++ b/backend/photos/models.py
@@ -42,8 +42,8 @@ class Photo(UUIDModel, VersionedModel):
     metering_mode                       = models.CharField(max_length=32, null=True)
     drive_mode                          = models.CharField(max_length=32, null=True)
     shooting_mode                       = models.CharField(max_length=32, null=True)
-    camera                              = models.ForeignKey(Camera, related_name='photos', null=True)
-    lens                                = models.ForeignKey(Lens, related_name='photos', null=True)
+    camera                              = models.ForeignKey(Camera, related_name='photos', null=True, on_delete=models.CASCADE)
+    lens                                = models.ForeignKey(Lens, related_name='photos', null=True, on_delete=models.CASCADE)
     latitude                            = models.DecimalField(max_digits=9, decimal_places=6, null=True)
     longitude                           = models.DecimalField(max_digits=9, decimal_places=6, null=True)
     altitude                            = models.DecimalField(max_digits=6, decimal_places=1, null=True)
@@ -86,7 +86,7 @@ class Photo(UUIDModel, VersionedModel):
         self.photo_tags.filter(tag__source=source, tag__type=type).delete()
 
 class PhotoFile(UUIDModel, VersionedModel):
-    photo               = models.ForeignKey(Photo, related_name='files')
+    photo               = models.ForeignKey(Photo, related_name='files', on_delete=models.CASCADE)
     path                = models.CharField(max_length=512)
     width               = models.PositiveSmallIntegerField()
     height              = models.PositiveSmallIntegerField()
@@ -117,7 +117,7 @@ TAG_TYPE_CHOICES = (
 
 
 class Face(UUIDModel, VersionedModel):
-    photo       = models.ForeignKey(Photo, related_name='faces')
+    photo       = models.ForeignKey(Photo, related_name='faces', on_delete=models.CASCADE)
     position_x  = models.FloatField()
     position_y  = models.FloatField()
     size_x      = models.FloatField()
@@ -130,7 +130,7 @@ class Face(UUIDModel, VersionedModel):
 
 class Tag(UUIDModel, VersionedModel):
     name            = models.CharField(max_length=128)
-    parent          = models.ForeignKey('Tag', related_name='+', null=True)
+    parent          = models.ForeignKey('Tag', related_name='+', null=True, on_delete=models.CASCADE)
     type            = models.CharField(max_length=1, choices=TAG_TYPE_CHOICES, null=True)
     source          = models.CharField(max_length=1, choices=SOURCE_CHOICES)
 
@@ -143,8 +143,8 @@ class Tag(UUIDModel, VersionedModel):
 
 
 class PhotoTag(UUIDModel, VersionedModel):
-    photo           = models.ForeignKey(Photo, related_name='photo_tags')
-    tag             = models.ForeignKey(Tag, related_name='photo_tags')
+    photo           = models.ForeignKey(Photo, related_name='photo_tags', on_delete=models.CASCADE)
+    tag             = models.ForeignKey(Tag, related_name='photo_tags', on_delete=models.CASCADE)
     source          = models.CharField(max_length=1, choices=SOURCE_CHOICES)
     model_version   = models.PositiveIntegerField(null=True)
     confidence      = models.FloatField()
@@ -152,7 +152,7 @@ class PhotoTag(UUIDModel, VersionedModel):
     verified        = models.BooleanField(default=False)
     hidden          = models.BooleanField(default=False)
     # Only if the tag type is 'Person'
-    face            = models.ForeignKey(Face, related_name='photo_tags', null=True)
+    face            = models.ForeignKey(Face, related_name='photo_tags', null=True, on_delete=models.CASCADE)
     # Optional bounding boxes from object detection
     position_x      = models.FloatField(null=True)
     position_y      = models.FloatField(null=True)

--- a/backend/photos/schema.py
+++ b/backend/photos/schema.py
@@ -1,10 +1,8 @@
 import django_filters
-from django_filters import Filter, CharFilter
 import graphene
-from graphene import Node
-from graphene_django.converter import convert_django_field
-from graphene_django.types import DjangoObjectType
+from django_filters import CharFilter
 from graphene_django.filter import DjangoFilterConnectionField
+from graphene_django.types import DjangoObjectType
 
 from .models import Camera, Lens, Photo, Tag
 

--- a/backend/photos/tests/conftest.py
+++ b/backend/photos/tests/conftest.py
@@ -1,6 +1,8 @@
-import pytest
-import mock
 import os
+
+import mock
+import pytest
+
 from django.conf import settings
 
 
@@ -22,5 +24,3 @@ def mock_redis(request):
     yield
     for m in mocks:
         m.stop()
-
-

--- a/backend/photos/tests/conftest.py
+++ b/backend/photos/tests/conftest.py
@@ -1,0 +1,26 @@
+import pytest
+import mock
+import os
+from django.conf import settings
+
+
+@pytest.fixture(scope='session')
+def django_db_modify_db_settings(django_db_modify_db_settings,):
+    os.environ['ENV'] = 'test'
+    settings.DATABASES['default'] = {
+        'ENGINE':   'django.db.backends.sqlite3',
+        'NAME':     ':memory:'
+    }
+
+
+@pytest.fixture(autouse=True)
+def mock_redis(request):
+    mocks = ['classifiers.base_model.Lock', 'classifiers.style.model.Lock', 'classifiers.object.model.Lock']
+    mocks = [mock.patch(x, mock.MagicMock()) for x in mocks]
+    for m in mocks:
+        m.start()
+    yield
+    for m in mocks:
+        m.stop()
+
+

--- a/backend/photos/tests/test_classifier_models.py
+++ b/backend/photos/tests/test_classifier_models.py
@@ -1,10 +1,7 @@
 import os
-import pytest
-import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-import mock
 
 
 def test_downloading(tmpdir):

--- a/backend/photos/tests/test_classifier_models.py
+++ b/backend/photos/tests/test_classifier_models.py
@@ -1,105 +1,101 @@
-from datetime import datetime
 import os
-from pathlib import Path
+import pytest
 import tempfile
 import time
+from datetime import datetime
+from pathlib import Path
+import mock
 
-import pytest
 
+def test_downloading(tmpdir):
+    from classifiers.style.model import StyleModel
 
-class TestClassifierModels:
-    def test_downloading(self):
-        from classifiers.style.model import StyleModel
+    model_dir = tmpdir
+    start = time.mktime(datetime.now().timetuple())
+    model = StyleModel(lock_name=None, model_dir=model_dir)
 
-        with tempfile.TemporaryDirectory() as model_dir:
-            start = time.mktime(datetime.now().timetuple())
-            model = StyleModel(lock_name=None, model_dir=model_dir)
+    graph_path = str(Path(model_dir) / 'style' / 'graph.pb')
+    assert os.stat(graph_path).st_size > 1024 * 10 * 10
+    assert os.stat(graph_path).st_mtime > start
+    with open(str(Path(model_dir) / 'style' / 'version.txt')) as f:
+        content = f.read()
+        assert content.strip() == str(model.version)
 
-            graph_path = str(Path(model_dir) / 'style' / 'graph.pb')
-            assert os.stat(graph_path).st_size > 1024 * 10 * 10
-            assert os.stat(graph_path).st_mtime > start
-            with open(str(Path(model_dir) / 'style' / 'version.txt')) as f:
-                content = f.read()
-                assert content.strip() == str(model.version)
+def test_color_predict():
+    from classifiers.color.model import ColorModel
 
-    def test_color_predict(self):
-        from classifiers.color.model import ColorModel
+    model = ColorModel()
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    result = model.predict(snow)
+    expected = [('Violet', '0.094'), ('Gray', '0.018'), ('Black', '0.006'), ('White', '0.005'), ('Pale pink', '0.001'), ('Dark orange', '0.000'), ('Dark lime green', '0.000')]
+    actual = [(x, '{:.3f}'.format(y)) for x, y in result]
+    assert expected == actual
 
-        model = ColorModel()
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        result = model.predict(snow)
+def test_location_predict():
+    from classifiers.location.model import LocationModel
 
-        assert len(result) == 7
-        assert result[0][0] == 'Violet'
-        assert '{0:.3f}'.format(result[0][1]) == '0.094'
-        assert result[1][0] == 'Gray'
-        assert '{0:.3f}'.format(result[1][1]) == '0.018'
+    model = LocationModel()
 
-    def test_location_predict(self):
-        from classifiers.location.model import LocationModel
+    # London, UK - Tests multiple polygons of the UK
+    result = model.predict(location=[51.5304213, -0.1286445])
+    assert result['country']['name'] == 'United Kingdom'
+    assert result['city']['name'] == 'London'
+    assert result['city']['distance'] == 1405
+    assert result['city']['population'] == 7556900
 
-        model = LocationModel()
+    # In the sea near Oia, Santorini, Greece - Country is inferred from city
+    result = model.predict(location=[36.4396445,25.3560936])
+    assert result['country']['name'] == 'Greece'
+    assert result['city']['name'] == 'Oía'
+    assert result['city']['distance'] == 3132
+    assert result['city']['population'] == 3376
 
-        # London, UK - Tests multiple polygons of the UK
-        result = model.predict(location=[51.5304213, -0.1286445])
-        assert result['country']['name'] == 'United Kingdom'
-        assert result['city']['name'] == 'London'
-        assert result['city']['distance'] == 1405
-        assert result['city']['population'] == 7556900
+    # Too far off the coast of John o' Groats, Scotland, UK - No match
+    result = model.predict(location=[58.6876742,-3.4206862])
+    assert result['country'] == None
+    assert result['city'] == None
 
-        # In the sea near Oia, Santorini, Greece - Country is inferred from city
-        result = model.predict(location=[36.4396445,25.3560936])
-        assert result['country']['name'] == 'Greece'
-        assert result['city']['name'] == 'Oía'
-        assert result['city']['distance'] == 3132
-        assert result['city']['population'] == 3376
+    # Vernier, Switzerland - Tests country code mainly (CH can be China in some codings)
+    result = model.predict(location=[46.1760906,5.9929043])
+    assert result['country']['name'] == 'Switzerland'
+    assert result['country']['code'] == 'CH'
+    assert result['city']['country_name'] == 'Switzerland'
+    assert result['city']['country_code'] == 'CH'
 
-        # Too far off the coast of John o' Groats, Scotland, UK - No match
-        result = model.predict(location=[58.6876742,-3.4206862])
-        assert result['country'] == None
-        assert result['city'] == None
+    # In France but close to a 'city' in Belgium - City should be limited to within border of country
+    result = model.predict(location=[51.074323, 2.547278])
+    assert result['country']['name'] == 'France'
+    assert result['city']['country_name'] == 'France'
+    assert result['city']['name'] == 'Téteghem'
 
-        # Vernier, Switzerland - Tests country code mainly (CH can be China in some codings)
-        result = model.predict(location=[46.1760906,5.9929043])
-        assert result['country']['name'] == 'Switzerland'
-        assert result['country']['code'] == 'CH'
-        assert result['city']['country_name'] == 'Switzerland'
-        assert result['city']['country_code'] == 'CH'
+def test_object_predict():
+    from classifiers.object.model import ObjectModel
 
-        # In France but close to a 'city' in Belgium - City should be limited to within border of country
-        result = model.predict(location=[51.074323, 2.547278])
-        assert result['country']['name'] == 'France'
-        assert result['city']['country_name'] == 'France'
-        assert result['city']['name'] == 'Téteghem'
+    model = ObjectModel()
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    result = model.predict(snow)
 
-    def test_object_predict(self):
-        from classifiers.object.model import ObjectModel
+    assert len(result) == 2
 
-        model = ObjectModel()
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        result = model.predict(snow)
+    assert result[0]['label'] == 'Tree'
+    assert '{0:.3f}'.format(result[0]['score']) == '0.950'
+    assert '{0:.3f}'.format(result[0]['significance']) == '0.226'
+    assert '{0:.3f}'.format(result[0]['x']) == '0.791'
+    assert '{0:.3f}'.format(result[0]['y']) == '0.394'
+    assert '{0:.3f}'.format(result[0]['width']) == '0.341'
+    assert '{0:.3f}'.format(result[0]['height']) == '0.700'
 
-        assert len(result) == 2
+    assert result[1]['label'] == 'Tree'
+    assert '{0:.3f}'.format(result[1]['score']) == '0.819'
+    assert '{0:.3f}'.format(result[1]['significance']) == '0.035'
 
-        assert result[0]['label'] == 'Tree'
-        assert '{0:.3f}'.format(result[0]['score']) == '0.950'
-        assert '{0:.3f}'.format(result[0]['significance']) == '0.226'
-        assert '{0:.3f}'.format(result[0]['x']) == '0.791'
-        assert '{0:.3f}'.format(result[0]['y']) == '0.394'
-        assert '{0:.3f}'.format(result[0]['width']) == '0.341'
-        assert '{0:.3f}'.format(result[0]['height']) == '0.700'
+def test_style_predict():
+    from classifiers.style.model import StyleModel
 
-        assert result[1]['label'] == 'Tree'
-        assert '{0:.3f}'.format(result[1]['score']) == '0.819'
-        assert '{0:.3f}'.format(result[1]['significance']) == '0.035'
+    model = StyleModel()
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    result = model.predict(snow)
 
-    def test_style_predict(self):
-        from classifiers.style.model import StyleModel
-
-        model = StyleModel()
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        result = model.predict(snow)
-
-        assert len(result) == 1
-        assert result[0][0] == 'serene'
-        assert '{0:.3f}'.format(result[0][1]) == '0.915'
+    assert len(result) == 1
+    assert result[0][0] == 'serene'
+    assert '{0:.3f}'.format(result[0][1]) == '0.915'

--- a/backend/photos/tests/test_classifier_runners.py
+++ b/backend/photos/tests/test_classifier_runners.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest

--- a/backend/photos/tests/test_classifier_runners.py
+++ b/backend/photos/tests/test_classifier_runners.py
@@ -1,119 +1,113 @@
-from datetime import datetime
 import os
 from pathlib import Path
-import tempfile
-import time
 
 import pytest
 
+# pytestmark = pytest.mark.django_db
+
 
 @pytest.fixture
-def photo_fixture_snow():
+def photo_fixture_snow(db):
     from photos.utils.db import record_photo
     snow_path = str(Path(__file__).parent / 'photos' / 'snow.jpg')
     return record_photo(snow_path)
 
 
 @pytest.fixture
-def photo_fixture_tree():
+def photo_fixture_tree(db):
     from photos.utils.db import record_photo
     tree_path = str(Path(__file__).parent / 'photos' / 'tree.jpg')
     return record_photo(tree_path)
 
 
-class TestClassifierRunners:
-    @pytest.mark.django_db
-    def test_color_via_runner(self, photo_fixture_snow):
-        from classifiers.color.model import run_on_photo
+def test_color_via_runner(photo_fixture_snow):
+    from classifiers.color.model import run_on_photo
 
-        # Path on it's own returns a None Photo object along with the result
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        photo, result = run_on_photo(snow)
+    # Path on it's own returns a None Photo object along with the result
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    photo, result = run_on_photo(snow)
 
-        assert photo is None
-        assert len(result) == 7
-        assert result[0][0] == 'Violet'
-        assert '{0:.3f}'.format(result[0][1]) == '0.094'
+    assert photo is None
+    assert len(result) == 7
+    assert result[0][0] == 'Violet'
+    assert '{0:.3f}'.format(result[0][1]) == '0.094'
 
-        # Passing in a Photo object should tag the object
-        assert photo_fixture_snow.photo_tags.count() == 0
-        photo, result = run_on_photo(photo_fixture_snow.id)
-        assert photo_fixture_snow.photo_tags.count() == 7
-        assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'Violet'
-        assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'C'
-        assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.094'
+    # Passing in a Photo object should tag the object
+    assert photo_fixture_snow.photo_tags.count() == 0
+    photo, result = run_on_photo(photo_fixture_snow.id)
+    assert photo_fixture_snow.photo_tags.count() == 7
+    assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'Violet'
+    assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'C'
+    assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.094'
 
-    @pytest.mark.django_db
-    def test_location_via_runner(self, photo_fixture_tree):
-        from classifiers.location.model import run_on_photo
+def test_location_via_runner(photo_fixture_tree):
+    from classifiers.location.model import run_on_photo
 
-        # Path on it's own returns a None Photo object along with the result
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        photo, result = run_on_photo(snow)
+    # Path on it's own returns a None Photo object along with the result
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    photo, result = run_on_photo(snow)
 
-        # This photo has no GPS coordinates
-        assert photo is None
-        assert result['city'] is None
-        assert result['country'] is None
+    # This photo has no GPS coordinates
+    assert photo is None
+    assert result['city'] is None
+    assert result['country'] is None
 
-        # Path which does have GPS coordinates
-        tree = str(Path(__file__).parent / 'photos' / 'tree.jpg')
-        photo, result = run_on_photo(tree)
-        assert result['country']['name'] == 'Greece'
-        assert result['country']['code'] == 'GR'
-        assert result['city']['name'] == 'Firá'
-        assert result['city']['country_name'] == 'Greece'
+    # Path which does have GPS coordinates
+    tree = str(Path(__file__).parent / 'photos' / 'tree.jpg')
+    photo, result = run_on_photo(tree)
+    assert result['country']['name'] == 'Greece'
+    assert result['country']['code'] == 'GR'
+    assert result['city']['name'] == 'Firá'
+    assert result['city']['country_name'] == 'Greece'
 
-        # Photo object with location to tag should have tags for country and city
-        assert photo_fixture_tree.photo_tags.count() == 0
-        photo, result = run_on_photo(photo_fixture_tree.id)
-        assert photo.photo_tags.all().count() == 2
-        assert photo.photo_tags.all()[0].tag.name == 'Greece'
-        assert photo.photo_tags.all()[0].confidence == 1.0
-        assert photo.photo_tags.all()[0].significance == 1.0
-        assert photo.photo_tags.all()[1].tag.name == 'Firá'
-        assert photo.photo_tags.all()[1].confidence == 0.5
-        assert photo.photo_tags.all()[1].significance == 0.5
-        assert photo.photo_tags.all()[1].tag.parent.name == 'Greece'
+    # Photo object with location to tag should have tags for country and city
+    assert photo_fixture_tree.photo_tags.count() == 0
+    photo, result = run_on_photo(photo_fixture_tree.id)
+    assert photo.photo_tags.all().count() == 2
+    assert photo.photo_tags.all()[0].tag.name == 'Greece'
+    assert photo.photo_tags.all()[0].confidence == 1.0
+    assert photo.photo_tags.all()[0].significance == 1.0
+    assert photo.photo_tags.all()[1].tag.name == 'Firá'
+    assert photo.photo_tags.all()[1].confidence == 0.5
+    assert photo.photo_tags.all()[1].significance == 0.5
+    assert photo.photo_tags.all()[1].tag.parent.name == 'Greece'
 
-    @pytest.mark.django_db
-    def test_object_via_runner(self, photo_fixture_snow):
-        from classifiers.object.model import run_on_photo
+def test_object_via_runner(photo_fixture_snow):
+    from classifiers.object.model import run_on_photo
 
-        # Path on it's own returns a None Photo object along with the result
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        photo, result = run_on_photo(snow)
+    # Path on it's own returns a None Photo object along with the result
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    photo, result = run_on_photo(snow)
 
-        assert photo is None
-        assert len(result) == 2
-        assert result[0]['label'] == 'Tree'
-        assert '{0:.3f}'.format(result[0]['significance']) == '0.226'
+    assert photo is None
+    assert len(result) == 2
+    assert result[0]['label'] == 'Tree'
+    assert '{0:.3f}'.format(result[0]['significance']) == '0.226'
 
-        # Passing in a Photo object should tag the object
-        assert photo_fixture_snow.photo_tags.count() == 0
-        photo, result = run_on_photo(photo_fixture_snow.id)
-        assert photo_fixture_snow.photo_tags.count() == 2
-        assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'Tree'
-        assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'O'
-        assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.226'
+    # Passing in a Photo object should tag the object
+    assert photo_fixture_snow.photo_tags.count() == 0
+    photo, result = run_on_photo(photo_fixture_snow.id)
+    assert photo_fixture_snow.photo_tags.count() == 2
+    assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'Tree'
+    assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'O'
+    assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.226'
 
-    @pytest.mark.django_db
-    def test_style_via_runner(self, photo_fixture_snow):
-        from classifiers.style.model import run_on_photo
+def test_style_via_runner(photo_fixture_snow):
+    from classifiers.style.model import run_on_photo
 
-        # Path on it's own returns a None Photo object along with the result
-        snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
-        photo, result = run_on_photo(snow)
+    # Path on it's own returns a None Photo object along with the result
+    snow = str(Path(__file__).parent / 'photos' / 'snow.jpg')
+    photo, result = run_on_photo(snow)
 
-        assert photo is None
-        assert len(result) == 1
-        assert result[0][0] == 'serene'
-        assert '{0:.3f}'.format(result[0][1]) == '0.915'
+    assert photo is None
+    assert len(result) == 1
+    assert result[0][0] == 'serene'
+    assert '{0:.3f}'.format(result[0][1]) == '0.915'
 
-        # Passing in a Photo object should tag the object
-        assert photo_fixture_snow.photo_tags.count() == 0
-        photo, result = run_on_photo(photo_fixture_snow.id)
-        assert photo_fixture_snow.photo_tags.count() == 1
-        assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'serene'
-        assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'S'
-        assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.915'
+    # Passing in a Photo object should tag the object
+    assert photo_fixture_snow.photo_tags.count() == 0
+    photo, result = run_on_photo(photo_fixture_snow.id)
+    assert photo_fixture_snow.photo_tags.count() == 1
+    assert photo_fixture_snow.photo_tags.all()[0].tag.name == 'serene'
+    assert photo_fixture_snow.photo_tags.all()[0].tag.type == 'S'
+    assert '{0:.3f}'.format(photo_fixture_snow.photo_tags.all()[0].significance) == '0.915'

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = web.settings
+DJANGO_SETTINGS_MODULE = web.test_settings

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,0 +1,24 @@
+from setuptools import find_packages, setup
+
+install_requires = [
+    'django', 'ipython', 'pillow', 'psutil', 'psycopg2-binary',
+    'python-redis-lock', 'requests', 'redis', 'rq', 'tensorflow', 'inotify',
+    'graphene-django', 'django-filter', 'pyshp', 'matplotlib', 'pytest',
+    'pytest-django', 'codecov', 'gunicorn', 'pip'
+]
+
+setup(
+    name='photomanager',
+    version='0.2',
+    packages=find_packages(),
+    description=("WIP"),
+    author="Damian Moore",
+    author_email="damian@epixstudios.co.uk",
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+    ],
+    install_requires=install_requires, )

--- a/backend/web/settings.py
+++ b/backend/web/settings.py
@@ -76,25 +76,15 @@ TEMPLATES = [
 WSGI_APPLICATION = 'web.wsgi.application'
 
 
-# Database
-# https://docs.djangoproject.com/en/1.10/ref/settings/#databases
-if os.environ.get('ENV') == 'test':
-    DATABASES = {
-        'default': {
-            'ENGINE':   'django.db.backends.sqlite3',
-            'NAME':     str(Path(BASE_DIR) / 'db.sqlite3'),
-        }
+DATABASES = {
+    'default': {
+        'ENGINE':   'django.db.backends.postgresql',
+        'HOST':     os.environ.get('POSTGRES_HOST', '127.0.0.1'),
+        'NAME':     'photo-manager',
+        'USER':     'postgres',
+        'PASSWORD': 'password',
     }
-else:
-    DATABASES = {
-        'default': {
-            'ENGINE':   'django.db.backends.postgresql',
-            'HOST':     os.environ.get('POSTGRES_HOST', '127.0.0.1'),
-            'NAME':     'photo-manager',
-            'USER':     'postgres',
-            'PASSWORD': 'password',
-        }
-    }
+}
 
 
 # Password validation

--- a/backend/web/test_settings.py
+++ b/backend/web/test_settings.py
@@ -1,0 +1,9 @@
+from .settings import *
+
+
+DATABASES = {
+    'default': {
+        'ENGINE':   'django.db.backends.sqlite3',
+        'NAME':     ':memory:'
+    }
+}


### PR DESCRIPTION
Hi Damian,

Please don't merge yet, just review for now.

I started by trying to run under python3.7 but could not work, django uses ``async`` as a keyword argument which upset python since it is now a keyword.

I have upgraded all packages in this commit and all the tests passes.

Latest Django demands an explicit ``on_delete`` defined for foreign keys, I assumed ``cascade`` is the right option but correct me if I am wrong.

I have defined a pytest conftest.py and added fixtures.  Mainly an autouse fixture to mock calls to redis, and another to specify ``:memory`` sqlite engine as the db.

I have also changed the tests from class styles to functions, and made use of pytest ``tmp`` fixture instead of using python ``tempfile``.

You can now run the tests without setting an env var ``ENV=test`` as the correct test db is hooked into pytest.ini.

You really need to choose a name for your project and reflect that on the ``setup.py`` file!

If you ``pip install pytest-xdist`` then you could run all the tests in parallel with ``pytest backend -n auto``.  We should hook the project into travis.ci soon.

Let's talk tomorrow.
Meitham 